### PR TITLE
Changed GapWalkForward.get_n_splits to match abstract method signatur…

### DIFF
--- a/tscv/split.py
+++ b/tscv/split.py
@@ -534,7 +534,7 @@ class GapWalkForward(GapCrossValidator):
         self.test_size = test_size
         self.gap_size = gap_size
 
-    def get_n_splits(self):
+    def get_n_splits(self, X=None, y=None, groups=None):
         return self.n_splits
 
     def split(self, X, y=None, groups=None):


### PR DESCRIPTION
…e. Now works with GridSearchCV.  Otherwise using GapWalkForward as the cross validation class passed to GridSearchCV will fail with "TypeError: get_n_splits() takes 1 positional argument but 4 were given."