### PR TITLE
Use pytest from conda-forge to prevent CI failure on Appveyor (Windows)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,15 +8,13 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
-      SKLEARN_VERSION: "0.22"
-
 #    - PYTHON: "C:\\Miniconda3-x64"
-#      PYTHON_VERSION: "3.9.x"
+#      PYTHON_VERSION: "3.6.x"
 #      PYTHON_ARCH: "64"
-#      SKLEARN_VERSION: "0.24"
+#      SKLEARN_VERSION: "0.22"
+
+    - PYTHON: "C:\\Miniconda3-x64"
+      PYTHON_ARCH: "64"
 
 install:
   # Prepend miniconda installed Python to the PATH of this build
@@ -24,8 +22,8 @@ install:
   # https://github.com/conda/conda/issues/1753
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
-  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION% pytest"
-  - pip install codecov nose pytest-cov
+  - "conda install --yes -c conda-forge pip"
+  - pip install pytest codecov nose pytest-cov
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 build: false
 
-image:
-  - Visual Studio 2019
-
 environment:
   matrix:
 
@@ -27,8 +24,8 @@ install:
   # https://github.com/conda/conda/issues/1753
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
-  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION%"
-  - pip install codecov nose pytest pytest-cov
+  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION% pytest=6.2.5"
+  - pip install codecov nose pytest-cov
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ install:
   - pip install .
 
 test_script:
-  - mkdir for_test
-  - cd for_test
+#  - mkdir for_test
+#  - cd for_test
   - pytest -v --cov=tscv --pyargs tscv
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   # https://github.com/conda/conda/issues/1753
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
-  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION% pytest=6.2.5"
+  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION% pytest"
   - pip install codecov nose pytest-cov
   - pip install .
 
@@ -33,7 +33,7 @@ test_script:
   - cd for_test
   - pytest -v --cov=tscv --pyargs tscv
 
-#after_test:
-#  - cp .coverage %APPVEYOR_BUILD_FOLDER%
-#  - cd %APPVEYOR_BUILD_FOLDER%
-#  - codecov
+after_test:
+  - cp .coverage %APPVEYOR_BUILD_FOLDER%
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
   - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION%"
-  - pip install codecov nose pytest pytest-cov
+  - pip install codecov cython nose pytest pytest-cov
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ install:
   # https://github.com/conda/conda/issues/1753
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
-  - "conda install --yes -c conda-forge pip"
-  - pip install pytest codecov nose pytest-cov
+  - "conda install --yes -c conda-forge pip pytest"
+  - pip install codecov nose pytest-cov
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,10 @@ environment:
       PYTHON_ARCH: "64"
       SKLEARN_VERSION: "0.22"
 
-    - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.9.x"
-      PYTHON_ARCH: "64"
-      SKLEARN_VERSION: "0.24"
+#    - PYTHON: "C:\\Miniconda3-x64"
+#      PYTHON_VERSION: "3.9.x"
+#      PYTHON_ARCH: "64"
+#      SKLEARN_VERSION: "0.24"
 
 install:
   # Prepend miniconda installed Python to the PATH of this build
@@ -31,8 +31,7 @@ install:
 test_script:
 #  - mkdir for_test
 #  - cd for_test
-#  - pytest -v --cov=tscv --pyargs tscv
-   - pytest -v
+  - pytest -v --cov=tscv --pyargs tscv
 
 #after_test:
 #  - cp .coverage %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ install:
   # https://github.com/conda/conda/issues/1753
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
-  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION%"
-  - pip install codecov nose pytest==6.2.5 pytest-cov
+  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION% pytest=6.2.5"
+  - pip install codecov nose pytest-cov
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 build: false
 
+image:
+  - Visual Studio 2019
+
 environment:
   matrix:
 
@@ -25,7 +28,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
   - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION%"
-  - pip install codecov cython nose pytest pytest-cov
+  - pip install codecov nose pytest pytest-cov
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ install:
   - pip install .
 
 test_script:
-#  - mkdir for_test
-#  - cd for_test
+  - mkdir for_test
+  - cd for_test
   - pytest -v --cov=tscv --pyargs tscv
 
 #after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ install:
   # https://github.com/conda/conda/issues/1753
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
-  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION% pytest=6.2.5"
-  - pip install codecov nose pytest-cov
+  - "conda install --yes -c conda-forge pip scikit-learn==%SKLEARN_VERSION%"
+  - pip install codecov nose pytest==6.2.5 pytest-cov
   - pip install .
 
 test_script:
@@ -34,7 +34,7 @@ test_script:
 #  - pytest -v --cov=tscv --pyargs tscv
    - pytest -v
 
-after_test:
-  - cp .coverage %APPVEYOR_BUILD_FOLDER%
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - codecov
+#after_test:
+#  - cp .coverage %APPVEYOR_BUILD_FOLDER%
+#  - cd %APPVEYOR_BUILD_FOLDER%
+#  - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,8 @@ install:
 test_script:
 #  - mkdir for_test
 #  - cd for_test
-  - pytest -v --cov=tscv --pyargs tscv
+#  - pytest -v --cov=tscv --pyargs tscv
+   - pytest -v
 
 after_test:
   - cp .coverage %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
pytest installed with pip has been failing on Appveyor since 6 days ago. I replaced it with the conda-forge one, and it works fine.