### PR TITLE
Consistently use the test sets as reference for `gap_before` and `gap_after` 

### DIFF
--- a/tscv/_split.py
+++ b/tscv/_split.py
@@ -69,6 +69,14 @@ class GapCrossValidator(metaclass=ABCMeta):
     Implementations must define one of the following 4 methods:
     `_iter_train_indices`, `_iter_train_masks`,
     `_iter_test_indices`, `_iter_test_masks`.
+
+    Parameters
+    ----------
+    gap_before : int, default=0
+        Gap before the test sets.
+
+    gap_after : int, default=0
+        Gap after the test sets.
     """
 
     def __init__(self, gap_before=0, gap_after=0):
@@ -106,6 +114,8 @@ class GapCrossValidator(metaclass=ABCMeta):
 
     # Since subclasses implement any of the following 4 methods,
     # none can be abstract.
+    # _iter_train_indices <- _iter_test_indices <-
+    # _iter_test_masks <- _iter_train_masks <- _iter_train_indices
     def _iter_train_indices(self, X=None, y=None, groups=None):
         """Generates integer indices corresponding to training sets.
 
@@ -151,7 +161,8 @@ class GapCrossValidator(metaclass=ABCMeta):
             yield mask
 
     def __complement_masks(self, masks):
-        before, after = self.gap_before, self.gap_after
+        # switch gap_before and gap_after because of different viewpoints
+        before, after = self.gap_after, self.gap_before
         for mask in masks:
             complement = np.ones(len(mask), dtype=np.bool_)
             for i, masked in enumerate(mask):

--- a/tscv/tests/test_split.py
+++ b/tscv/tests/test_split.py
@@ -61,8 +61,8 @@ def test_gap_cross_validator():
     masks = cv._GapCrossValidator__complement_masks(
         [[False,  True,  True,  True, False, False],
          [False, False, False, False, False,  True]])
-    assert_array_equal(next(masks), [True, False, False, False, False, False])
-    assert_array_equal(next(masks), [True, True, True, True, True, False])
+    assert_array_equal(next(masks), [False, False, False, False, True, True])
+    assert_array_equal(next(masks), [True, True, True, False, False, False])
 
     indices = cv._GapCrossValidator__complement_indices([[1, 2, 3], [5]], 7)
     assert_array_equal(next(indices), [0, 6])
@@ -73,12 +73,12 @@ def test_gap_cross_validator():
     assert_array_equal(next(masks), [False, False, True, False, True])
 
     masks = cv._iter_test_masks("abcde")
-    assert_array_equal(next(masks), [True, False, False, False, False])
-    assert_array_equal(next(masks), [True, True, False, False, False])
+    assert_array_equal(next(masks), [False, False, False, False, True])
+    assert_array_equal(next(masks), [False, False, False, False, False])
 
     indices = cv._iter_test_indices("abcde")
-    assert_array_equal(next(indices), [0])
-    assert_array_equal(next(indices), [0, 1])
+    assert_array_equal(next(indices), [4])
+    assert_array_equal(next(indices), [])
 
     # Another dummy subclass
     class test2CV(GapCrossValidator):


### PR DESCRIPTION
There are two ways of defining a derived cross-validator. One is to redefine ` _iter_test_indices` or `_iter_test_masks` (**test viewpoint**), and the other is to redefine `_iter_train_masks` or `_iter_train_indices` (**train viewpoint**). 

Currently, these two methods assign different semantic meanings to the parameters `gap_before` and `gap_after`. The test viewpoint uses the test sets as the reference:
```
train    gap_before    test    gap_after    train
```
The train viewpoint uses the training sets as the reference:
```
test    gap_before    train    gap_after    test
```

This diverged behavior is ~~not intended~~ inappropriate. The package should insist on the test viewpoint, and hence this PR. It will be enforced in `v0.2`.

I don't think this issue has touched any users, for the derived classes in this package use `_iter_test_indices` exclusively (test viewpoint). No users have reported this issue either. If you suspect that you have been affected by it, please reply to this PR.